### PR TITLE
init pixelWidth/Height

### DIFF
--- a/src/gohai/glvideo/GLVideo.java
+++ b/src/gohai/glvideo/GLVideo.java
@@ -147,6 +147,8 @@ public class GLVideo extends PImage {
         this.height = texture.height;
         this.format = ARGB;
         this.pixelDensity = 1;
+        this.pixelWidth = this.width * this.pixelDensity;
+        this.pixelHeight = this.height * this.pixelDensity;         
         pg.setCache(this, texture);
       } else {
         texture.glName = texId;


### PR DESCRIPTION
pixelWidth and pixelHeight are used inside PImage, nee to be initialized explicitly in GLVideo since PImage.init() is not being used.